### PR TITLE
docs: add upnode tools, snapshots and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@
     * The CPU is another possible bottleneck, especially CPU frequency. Some users have reported that overclocking has helped dissipate the problem.
     * For validators on AWS,`i4i.2xlarge` is a good example of machine spec which has been reported to work without issues.
     * For more context, [please see this relevant discussion](https://discord.com/channels/924442927399313448/1245159849986228284/1273677626615009443).
-* **How do I address empty blocks on my validator?**
-    * Try the recommendations above.
-    * If you are using reth execution client, try bumping to [v1.0.8](https://github.com/paradigmxyz/reth/releases/tag/v1.0.8). Some validators reported that this solved the empty blocks issue.
 * **My BGT rewards are delayed or missing!**
   * Please review your cutting board, ensure that the weights are setup exactly the way you expect them.
   * You can use any of [these tools](#pol) to make the job easy.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [Monitoring](#monitoring)  
 [Proof of Liquidity](#pol)  
 [Data](#data)  
+[Tooling](#tooling)  
 [Snapshots](#snapshots)  
 [FAQ](#faq)  
 
@@ -28,6 +29,11 @@
 * [Nodes map](https://services.tienthuattoan.com/testnet/berachain-v2/map) - Berachain v2 nodes map
 * [B-Harvest dashboard](https://bera-dashboard.bharvest.io/) - Validators data by B-Harvest
 
+## Tooling
+
+* [berachain-docker-node](https://github.com/upnodedev/berachain-docker-node) - Docker compose script to run Berachain node in a single command
+* [bera-snap](https://github.com/upnodedev/bera-snap) - Auto snapshots tool for berachain-docker-node with configurable cron scheduling, REST API for snapshot distribution, and optional GCS upload
+
 ## Snapshots
 
 | Provider                                                                                                        | Database  |
@@ -46,14 +52,18 @@
 | [Staketab](https://services.staketab.org/docs/beacon-testnet/snapshot)                                          | pebbledb  |
 | [Synergy Nodes](https://synergynodes.com/service/berachain-v2-testnet)                                          | pebbledb  |
 | [TTT VN](https://services.tienthuattoan.com/testnet/berachain-v2/snapshot)                                      | pebbledb  |
+| [Upnode](https://bera.upnode.org/berachainv2/snapshots)                                                         | pebbledb  |
 
 ## FAQ
 * **How do I address missed blocks on my validator?**
     * Check disk I/O metrics, make sure your node can keep up.
     * NVMe storage is highly recomended over SSDs for better performance.
-    * The CPU is another possible bottleneck. Some users have reported that overclocking has helped dissipate the problem.
+    * The CPU is another possible bottleneck, especially CPU frequency. Some users have reported that overclocking has helped dissipate the problem.
     * For validators on AWS,`i4i.2xlarge` is a good example of machine spec which has been reported to work without issues.
     * For more context, [please see this relevant discussion](https://discord.com/channels/924442927399313448/1245159849986228284/1273677626615009443).
+* **How do I address empty blocks on my validator?**
+    * Try the recommendations above.
+    * If you are using reth execution client, try bumping to [v1.0.8](https://github.com/paradigmxyz/reth/releases/tag/v1.0.8). Some validators reported that this solved the empty blocks issue.
 * **My BGT rewards are delayed or missing!**
   * Please review your cutting board, ensure that the weights are setup exactly the way you expect them.
   * You can use any of [these tools](#pol) to make the job easy.


### PR DESCRIPTION
We've added beacond & reth snapshots and open-source tools by Upnode:

- [berachain-docker-node](https://github.com/upnodedev/berachain-docker-node) (tested on our validator and rpc nodes)
- [bera-snap](https://github.com/upnodedev/bera-snap) (used for our snapshots)

We also added some notes on missed blocks and empty blocks. These were made in our experience, moving to reth v1.0.8 from v1.0.6 supposedly helped eliminate empty blocks.